### PR TITLE
ci(dependabot): remove python and dev container support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,44 +21,8 @@ updates:
     package-ecosystem: npm
     reviewers:
       - blade2005
-    groups:
-      production-dependencies:
-        dependency-type: production
-      dev-dependencies:
-        dependency-type: development
     schedule:
       day: monday
       interval: weekly
       time: "08:00"
       timezone: America/New_York
-  - directory: /
-    # ignore:
-    #   - dependency-name: boto3
-    #   - dependency-name: botocore
-    labels:
-      - dependencies
-      - poetry
-      - python
-    open-pull-requests-limit: 10
-    package-ecosystem: pip
-    reviewers:
-      - blade2005
-    groups:
-      production-dependencies:
-        dependency-type: production
-      dev-dependencies:
-        dependency-type: development
-    schedule:
-      day: monday
-      interval: weekly
-      time: "08:00"
-      timezone: America/New_York
-      # versioning-strategy can be used for projects that need more control
-      # over when version constraints are changed.
-      # versioning-strategy: lockfile-only
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: weekly
-    reviewers:
-      - blade2005


### PR DESCRIPTION
This project doesn't use python or dev-containers. No need for it to be in the repo
