### PR TITLE
fix(argocd-rtorrent): move defaultMode to advancedMounts sub section

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -59,7 +59,7 @@ spec:
             enabled: true
             name: rtorrent-app-rtorrent-config
             type: configMap
-            defaultMode: '0700'
+            defaultMode: 488
             advancedMounts:
               main:
                 main:


### PR DESCRIPTION
defaultMode isn't valid for the configMap type, but might be valid under the advanced mounts configuration
