### PR TITLE
fix(rtorrent/flood): set user/pass for flood

### DIFF
--- a/.cspell-dictionaries/homelab.txt
+++ b/.cspell-dictionaries/homelab.txt
@@ -218,3 +218,5 @@ devcontainers
 eitsupi
 infracost
 prulloac
+DEUSER
+DEPASS

--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -37,6 +37,12 @@ spec:
                   FLOOD_OPTION_ALLOWEDPATH: "/library"
                   FLOOD_OPTION_AUTH: "none" # service is behind CloudFlare OAuth
                   FLOOD_OPTION_RTSOCKET: "/config/.local/share/rtorrent/rtorrent.sock"
+                  FLOOD_OPTION_DEUSER: "admin"
+                  FLOOD_OPTION_DEPASS:
+                    valueFrom:
+                      secretKeyRef:
+                        name: rtorrent-secret
+                        key: pass
         service:
           main:
             controller: main


### PR DESCRIPTION
With auth set to none, it uses torrent client credentials, so we are passing that in.
