### PR TITLE
fix(flood): enable default auth

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -36,14 +36,8 @@ spec:
                   FLOOD_OPTION_PORT: 3000
                   FLOOD_OPTION_RTORRENT: "true"
                   FLOOD_OPTION_ALLOWEDPATH: "/library"
-                  FLOOD_OPTION_AUTH: "none" # service is behind CloudFlare OAuth
+                  FLOOD_OPTION_AUTH: "default"
                   FLOOD_OPTION_RTSOCKET: "/config/.local/share/rtorrent/rtorrent.sock"
-                  FLOOD_OPTION_DEUSER: "admin"
-                  FLOOD_OPTION_DEPASS:
-                    valueFrom:
-                      secretKeyRef:
-                        name: rtorrent-secret
-                        key: pass
         service:
           main:
             controller: main


### PR DESCRIPTION
Auth with Sonarr isn't working, it was before, so trying out re-enabling the default method of auth flood uses
