### PR TITLE
fix(rtorrent): disable completion path script mount

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -70,9 +70,9 @@ spec:
                   - path: /config/.rtorrent.rc
                     readOnly: false
                     subPath: .rtorrent.rc
-                  - path: /config/completion-path.sh
-                    readOnly: false
-                    subPath: completion-path
+                    # - path: /config/completion-path.sh
+                    #   readOnly: false
+                    #   subPath: completion-path
         configMaps:
           rtorrent-config:
             enabled: true


### PR DESCRIPTION
I think something went wrong with the mounting and it's not working the same as the rtorrent.rc
