### PR TITLE
fix(rtorrent): update path for init container for bash

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -32,7 +32,7 @@ spec:
                   repository: bash
                   tag: latest
                 command:
-                  - /bin/bash
+                  - /usr/local/bin/bash
                   - -c
                 args:
                   - |


### PR DESCRIPTION
It's located in /usr/local/bin not /bin
