### PR TITLE
fix(rtorrent): remove completion-path.sh if it's a directory

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -36,8 +36,11 @@ spec:
                   - -c
                 args:
                   - |
-                    touch /config/completion-path.sh;
-                    stat /config/completion-path.sh;
+                    scriptPath=/config/completion-path.sh;
+                    stat $scriptPath;
+                    if [[ -d $scriptPath ]];then rmdir $scriptPath;fi;
+                    touch $scriptPath;
+                    stat $scriptPath;
             containers:
               main:
                 image:
@@ -82,6 +85,9 @@ spec:
                   - path: /config/.rtorrent.rc
                     readOnly: false
                     subPath: .rtorrent.rc
+                  - path: /config/completion-path
+                    readOnly: false
+                    subPath: completion-path
                   - path: /config/completion-path.sh
                     readOnly: false
                     subPath: completion-path


### PR DESCRIPTION
Remove the completion-path.sh if it's a directory and touch it as a file. Also added a new path for the volume as /config/completion-path and manually touched it as a file
