### PR TITLE
fix(rtorrent-scripts): fix spelling on the completion-path.sh name

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -82,8 +82,8 @@ spec:
           scripts:
             enabled: true
             data:
-              completetion-path.sh: |
-                #! /usr/bin/env bash
+              completion-path.sh: |
+                #! /usr/bin/env ash
                 #
                 # Determine a dynamic completion path and print it on stdout for capturing
                 #
@@ -191,7 +191,6 @@ spec:
                 done
                 #set | egrep '^[a-z_]+=' >&2
 
-                echo "completion-path '$default' '$session' '$hash' '$name' '$directory' '$base_path' '$tied_to_file' '$is_multi_file' '$label' '$display_name'" >> /config/completion-path.log
                 # Determine target path
                 target=""
                 set_target_path


### PR DESCRIPTION
This caused rtorrent not to execute the script. I also fixed the interpreter as bash isn't installed on this image but ash is. They are similar I don't expect there to be problems. I also remove the logging as rtorrent itself logs the execution of scripts
