### PR TITLE
fix(rtorrent): set image to a custom one I made

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -29,7 +29,7 @@ spec:
             containers:
               main:
                 image:
-                  repository: jesec/rtorrent-flood
+                  repository: blade2005/flood-rtorrent
                   tag: latest
                   pullPolicy: IfNotPresent
                 env:
@@ -83,7 +83,7 @@ spec:
             enabled: true
             data:
               completion-path.sh: |
-                #! /usr/bin/env ash
+                #! /usr/bin/env bash
                 #
                 # Determine a dynamic completion path and print it on stdout for capturing
                 #


### PR DESCRIPTION
turns out ash doesn't do arrays like bash so I need bash, this is a first pass at using a custom image with k8s for rtorrent. we'll see how it goes
