### PR TITLE
fix(rtorrent): set to always pull the latest image

### DIFF
--- a/kubernetes/apps/homelab/rtorrent/svc.yaml
+++ b/kubernetes/apps/homelab/rtorrent/svc.yaml
@@ -31,7 +31,7 @@ spec:
                 image:
                   repository: blade2005/flood-rtorrent
                   tag: latest
-                  pullPolicy: IfNotPresent
+                  pullPolicy: Always
                 env:
                   FLOOD_OPTION_RUNDIR: /config
                   HOME: /config


### PR DESCRIPTION
Since I'm using latest tags and not cutting releases this makes it hard to ensure i'm running the latest unless i'm also limiting with sha and setting up renovate to update(soon but not yet)
