### PR TITLE
fix(homepage): reloader annotation in wrong location

### DIFF
--- a/kubernetes/apps/homelab/homepage/svc.yaml
+++ b/kubernetes/apps/homelab/homepage/svc.yaml
@@ -16,8 +16,10 @@ spec:
     targetRevision: 1.2.3
     helm:
       valuesObject:
-        annotations:
-          reloader.stakater.com/auto: "true"
+        controller:
+          main:
+            annotations:
+              reloader.stakater.com/auto: "true"
         image:
           repository: ghcr.io/gethomepage/homepage
           # renovate: datasource=docker depName=ghcr.io/gethomepage/homepage


### PR DESCRIPTION
The annotation needs to be on the controller so it will be put on the pod so reloader will use it.
