### PR TITLE
fix(homepage): annotations live directly on the controller key

### DIFF
--- a/.cspell-dictionaries/k8s.txt
+++ b/.cspell-dictionaries/k8s.txt
@@ -15,3 +15,4 @@ scontrolplane
 servicelb
 snodes
 storageclass
+bjw

--- a/kubernetes/apps/homelab/homepage/svc.yaml
+++ b/kubernetes/apps/homelab/homepage/svc.yaml
@@ -17,9 +17,8 @@ spec:
     helm:
       valuesObject:
         controller:
-          main:
-            annotations:
-              reloader.stakater.com/auto: "true"
+          annotations:
+            reloader.stakater.com/auto: "true"
         image:
           repository: ghcr.io/gethomepage/homepage
           # renovate: datasource=docker depName=ghcr.io/gethomepage/homepage


### PR DESCRIPTION
Unlike with 3.2.1 bjw-s/common, the 1.3.1 version of bjw-s/common that the homepage chart uses the controller is always main and is setup much differently than the newer one I'm used to
