### PR TITLE
fix(homepage): layout is array not a dictionary

### DIFF
--- a/kubernetes/apps/homelab/homepage/svc.yaml
+++ b/kubernetes/apps/homelab/homepage/svc.yaml
@@ -236,11 +236,13 @@ spec:
           settings:
             theme: dark
             layout:
-              Media:
-                style: row
-                columns: 4
-              Kubernetes:
-                initiallyCollapsed: true
+              - Media:
+                  style: row
+                  columns: 4
+              - Kubernetes:
+                  initiallyCollapsed: true
+                  style: row
+                  columns: 4
         # The service account is necessary to allow discovery of other services
         serviceAccount:
           create: true


### PR DESCRIPTION
Layout ordering determines the order keys show up on the homepage, by using a dictionary it become alphabetical, by using an array it's ordered as intended.
