### PR TITLE
fix(leantime-tunnel): update service name

### DIFF
--- a/kubernetes/apps/selfhosted/leantime/tunnel.yaml
+++ b/kubernetes/apps/selfhosted/leantime/tunnel.yaml
@@ -22,7 +22,7 @@ spec:
           tunnelName: "faerun-leantime"
           ingress:
             - hostname: "lt.fieldsofbears.com"
-              service: "http://leantime-svc.leantime.svc.cluster.local:80"
+              service: "http://leantime-svc-main.leantime.svc.cluster.local:80"
   destination:
     server: "https://kubernetes.default.svc"
     namespace: leantime


### PR DESCRIPTION
When I upgraded to the newer version of the common helm chart, it caused the service name to change too
