### PR TITLE
fix(volsync): set the app names correctly to volsync related

### DIFF
--- a/kubernetes/main/system/volsync/app.yaml
+++ b/kubernetes/main/system/volsync/app.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: debian-ceph
+  name: volsync
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/kubernetes/main/system/volsync/svc.yaml
+++ b/kubernetes/main/system/volsync/svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: debian-ceph
+  name: volsync-svc
   namespace: argocd
   finalizers:
     - resources-finalizer.argocd.argoproj.io


### PR DESCRIPTION
The names were left on old stuff from the copy I did
