### PR TITLE
feat(onepassword-connect): add app for onepassword-connect and appset for system(to deploy system related apps)

### DIFF
--- a/.cspell-dictionaries/k8s.txt
+++ b/.cspell-dictionaries/k8s.txt
@@ -27,3 +27,5 @@ backblaze
 onepassword
 RESTIC
 openebs
+missingkey
+appset

--- a/kubernetes/main/system/appset.yaml
+++ b/kubernetes/main/system/appset.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj.io/applicationset_v1alpha1.json
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: system
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  syncPolicy:
+    applicationsSync: create-delete
+  generators:
+    - list:
+        elements:
+          - dirName: onepassword-connect
+            appName: onepassword-connect
+            namespace: external-secrets
+  template:
+    metadata:
+      name: "{{.appName}}-app"
+      namespace: argocd
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          selfHeal: true
+          prune: true
+        syncOptions:
+          - CreateNamespace=true
+      source:
+        repoURL: git@github.com:blade2005/homelab.git
+        targetRevision: main
+        path: kubernetes/main/system/{{.dirName}}
+        directory:
+          recurse: true
+          jsonnet: {}
+      destination:
+        server: "https://kubernetes.default.svc"
+        namespace: '{{default "system" .namespace }}'

--- a/kubernetes/main/system/onepassword-connect/svc.yaml
+++ b/kubernetes/main/system/onepassword-connect/svc.yaml
@@ -1,0 +1,130 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/argoproj.io/application_v1alpha1.json
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: onepassword-connect
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+  source:
+    repoURL: https://bjw-s.github.io/helm-charts
+    chart: app-template
+    targetRevision: 3.2.1
+    helm:
+      valuesObject:
+        controllers:
+          onepassword-connect:
+            strategy: RollingUpdate
+            annotations:
+              reloader.stakater.com/auto: "true"
+            containers:
+              api:
+                image:
+                  repository: docker.io/1password/connect-api
+                  tag: 1.7.3
+                env:
+                  XDG_DATA_HOME: &configDir /config
+                  OP_HTTP_PORT: &apiPort 80
+                  OP_BUS_PORT: 11220
+                  OP_BUS_PEERS: localhost:11221
+                  OP_SESSION:
+                    valueFrom:
+                      secretKeyRef:
+                        name: onepassword-connect-secret
+                        key: 1password-credentials.json
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /heartbeat
+                        port: *apiPort
+                      initialDelaySeconds: 15
+                      periodSeconds: 30
+                      failureThreshold: 3
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /health
+                        port: *apiPort
+                      initialDelaySeconds: 15
+                securityContext: &securityContext
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  capabilities: {drop: ["ALL"]}
+                resources: &resources
+                  requests:
+                    cpu: 10m
+                  limits:
+                    memory: 256M
+              sync:
+                image:
+                  repository: docker.io/1password/connect-sync
+                  tag: 1.7.3
+                env:
+                  XDG_DATA_HOME: *configDir
+                  OP_HTTP_PORT: &syncPort 8081
+                  OP_BUS_PORT: 11221
+                  OP_BUS_PEERS: localhost:11220
+                  OP_SESSION:
+                    valueFrom:
+                      secretKeyRef:
+                        name: onepassword-connect-secret
+                        key: 1password-credentials.json
+                probes:
+                  liveness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /heartbeat
+                        port: *syncPort
+                      initialDelaySeconds: 15
+                      periodSeconds: 30
+                      failureThreshold: 3
+                  readiness:
+                    enabled: true
+                    custom: true
+                    spec:
+                      httpGet:
+                        path: /health
+                        port: *syncPort
+                      initialDelaySeconds: 15
+                securityContext: *securityContext
+                resources: *resources
+        defaultPodOptions:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: {type: RuntimeDefault}
+        service:
+          app:
+            controller: onepassword-connect
+            ports:
+              http:
+                port: *apiPort
+        persistence:
+          config:
+            type: emptyDir
+            globalMounts:
+              - path: *configDir


### PR DESCRIPTION
onepassword will allow me to support external secrets and appset allows me to streamline generation of apps.
