### PR TITLE
fix(system-appset): remove onepassword-connect

### DIFF
--- a/kubernetes/main/system/appset.yaml
+++ b/kubernetes/main/system/appset.yaml
@@ -12,10 +12,10 @@ spec:
     applicationsSync: create-delete
   generators:
     - list:
-        elements:
-          - dirName: onepassword-connect
-            appName: onepassword-connect
-            namespace: external-secrets
+        elements: []
+        # - dirName: onepassword-connect
+        #   appName: onepassword-connect
+        #   namespace: external-secrets
   template:
     metadata:
       name: "{{.appName}}-app"


### PR DESCRIPTION
Remove onepassword-connect for 2 reasons.

1. test how to remove applications from an ApplicationSet.
2. Refactor onepassword-connect to not use an app-of-apps deployment strategy.

An app of apps isn't ideal for me as it necessitates a painful parent app removal process if the parent app is managing itself. With ApplicationSet I hope to move away from this recursion pattern and just use ApplicationSet to deploy groups of Applications.
