### PR TITLE
feat(argocd-ansible): enable helm support for kustomize in argocd

### DIFF
--- a/ansible/roles/k3s-controlplane/tasks/singleton.yml
+++ b/ansible/roles/k3s-controlplane/tasks/singleton.yml
@@ -117,6 +117,7 @@
             namespace: argocd
           data:
             url: https://argocd.{{ k3s_cloudflare_domain_name }}
+            kustomize.buildOptions: --enable-helm
             accounts.homepage: apiKey
             accounts.cdavis: login, apiKey
             dex.config: |


### PR DESCRIPTION
In order to deploy applications which are Kustomize that use helm charts I need to enable a buildOption for it to work
