### PR TITLE
docs(onepassword-connect): add deploy instructions

### DIFF
--- a/kubernetes/main/system/onepassword-connect/README.md
+++ b/kubernetes/main/system/onepassword-connect/README.md
@@ -1,0 +1,7 @@
+# onepassword-connect
+
+## Deployment
+
+Create secret `onepassword-connect-secret` with the data `1password-credentials.json`.
+
+TODO: Securely store this in the repository to enable bootstrapping the cluster.


### PR DESCRIPTION
A manual step is still needed so that the connect server is connected to 1password itself.
