### PR TITLE
fix(argocd): quote true on the configmap

### DIFF
--- a/ansible/roles/k3s-controlplane/tasks/singleton.yml
+++ b/ansible/roles/k3s-controlplane/tasks/singleton.yml
@@ -141,7 +141,7 @@
             namespace: argocd
           data:
             server.insecure: "true"
-            applicationsetcontroller.enable.progressive.syncs: true
+            applicationsetcontroller.enable.progressive.syncs: "true"
     - name: ArgoCD RBAC ConfigMap
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION
when passing the yaml from ansible through to the configmap I need the literal true not the true value. yay yaml and strings
