### PR TITLE
fix(system-ApplicationSet): fix filter logic for rollout step

### DIFF
--- a/kubernetes/main/appsets/system.yaml
+++ b/kubernetes/main/appsets/system.yaml
@@ -26,12 +26,12 @@ spec:
     rollingSync:
       steps:
         - matchExpressions:
-            - key: groupLabel
+            - key: deployGroup
               operator: In
               values:
                 - A
         - matchExpressions:
-            - key: groupLabel
+            - key: deployGroup
               operator: In
               values:
                 - B
@@ -39,6 +39,8 @@ spec:
     metadata:
       name: "{{.appName}}"
       namespace: argocd
+      labels:
+        deployGroup: "{{.group}}"
     spec:
       project: default
       syncPolicy:


### PR DESCRIPTION
The match expression key is based off the labels in use from the generated template. So the data from the list generator would change the values in the label but the match expression key is from the label.
