### PR TITLE
fix(argocd-auth): set dex.config to empty string

### DIFF
--- a/ansible/roles/k3s-controlplane/tasks/singleton.yml
+++ b/ansible/roles/k3s-controlplane/tasks/singleton.yml
@@ -127,6 +127,7 @@
             kustomize.buildOptions: --enable-helm
             accounts.homepage: apiKey
             accounts.cdavis: login, apiKey
+            dex.config: ""
     - name: ArgoCD CMD Params ConfigMap
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION
Previously I removed dex.config, but that didn't remove the dex.config only omitted setting it, I need to wipe it out so it's not using github oauth anymore
