### PR TITLE
build(gitignore): add charts/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+charts/


### PR DESCRIPTION
Building kustomize leaves the inflated charts behind. While production practies says to inflate and use the inflated version instead of remote url, I'm fine right now taking this option
